### PR TITLE
HC-8 Convert Survey Responses to CSV Ahead of Download

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -70,6 +70,11 @@ class AssessmentsController < ApplicationController
     end
   end
 
+  # def export_responses
+  #   csv_data = ConvertResponsesToCsv.new(@assessment).export_responses_to_csv
+  #   send_data csv_data, filename: "responses.csv", type: "text/csv"
+  # end
+
   private
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/public/survey_responses_controller.rb
+++ b/app/controllers/public/survey_responses_controller.rb
@@ -1,6 +1,7 @@
 module Public
   class SurveyResponsesController < ApplicationController
     before_action :set_assessment
+    before_action :add_blocks_for_users_without_accounts, only: :show
 
     def show
       @template_version = @assessment.template_version
@@ -9,6 +10,10 @@ module Public
 
     def create
       @survey_response = @assessment.survey_responses.new(survey_response_params)
+      if Current.user
+        @survey_response.respondent_email = Current.user.email
+        @survey_response.respondent_id = Current.user.id
+      end
 
       if @survey_response.save
         redirect_to thank_you_public_survey_response_path(token: @assessment.token), notice: "Thank you for completing the survey!"
@@ -27,6 +32,31 @@ module Public
       @assessment = Assessment.find_by!(token: params[:token])
     rescue ActiveRecord::RecordNotFound
       redirect_to root_path, alert: "Survey not found"
+    end
+
+    def add_blocks_for_users_without_accounts
+      @template_version = @assessment.template_version
+      unless Block.where(template_version: @template_version, block_type: "short_text", question: "Full Name:").any?
+        Block.create(
+          block_type: "short_text",
+          question: "Full Name:",
+          position: 1,
+          config: {"required" => "1", "max_length" => "100", "min_length" => "0",
+                   "button_text" => "Next", "description" => "", "placeholder" => ""},
+          template_version: @template_version
+        )
+      end
+
+      unless Block.where(template_version: @template_version, block_type: "short_text", question: "Email:").any?
+        Block.create(
+          block_type: "short_text",
+          question: "Email:",
+          position: 2,
+          config: {"required" => "1", "max_length" => "100", "min_length" => "0",
+                   "button_text" => "Next", "description" => "", "placeholder" => ""},
+          template_version: @template_version
+        )
+      end
     end
 
     def survey_response_params

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -25,6 +25,14 @@ class Block < ApplicationRecord
     :placeholder, :min_length, :max_length, :min_value, :max_value,
     :date_format, :min_date, :max_date
 
+  scope :conditionally_exclude_email_and_full_name, -> {
+    if Current.user.present?
+      where.not(question: ["Email:", "Full Name:"])
+    else
+      all
+    end
+  }
+
   scope :ungrouped, -> { where(block_group_id: nil) }
   # validates :button_text, presence: true
   # validates :required, inclusion: { in: %w[0 1] }, allow_nil: true

--- a/app/models/survey_response.rb
+++ b/app/models/survey_response.rb
@@ -1,5 +1,6 @@
 class SurveyResponse < ApplicationRecord
   belongs_to :assessment
+  belongs_to :respondent, class_name: "User", optional: true
 
   has_many :responses, dependent: :destroy
 

--- a/app/models/template_version.rb
+++ b/app/models/template_version.rb
@@ -2,7 +2,7 @@ class TemplateVersion < ApplicationRecord
   belongs_to :survey_template
   belongs_to :created_by, class_name: "User"
 
-  has_many :blocks, -> { order(position: :asc) }, dependent: :destroy
+  has_many :blocks, -> { order(position: :asc).conditionally_exclude_email_and_full_name }, dependent: :destroy
   has_many :block_groups, dependent: :destroy
   has_many :assessments, dependent: :destroy
 

--- a/app/services/convert_responses_to_csv.rb
+++ b/app/services/convert_responses_to_csv.rb
@@ -1,0 +1,67 @@
+require "csv"
+
+class ConvertResponsesToCsv
+  def initialize(assessment)
+    # eager load the survey_responses, responses and blocks into the assessment when this is called from the controller
+    @assessment = assessment
+  end
+
+  def export_responses_to_csv
+    CSV.generate(headers: true) do |csv|
+      csv << generate_headers
+
+      @assessment.survey_responses.each do |sr|
+        csv << generate_row_data(sr)
+      end
+    end
+  end
+
+  def generate_headers
+    responses = filtered_responses(@assessment.survey_responses.first)
+    headers_array = ["Name", "Email", "Submitted On"]
+    responses.each do |r|
+      headers_array << r.block.question
+    end
+
+    headers_array
+  end
+
+  def generate_row_data(sr)
+    row_data = [
+      extract_name_from_survey_response(sr),
+      extract_email_from_survey_response(sr),
+      sr.created_at
+    ]
+    filtered_responses(sr).each do |r|
+      row_data << extract_answer_from_response_data(r.response_data)
+    end
+
+    row_data
+  end
+
+  def extract_answer_from_response_data(response_data)
+    case response_data.keys.first
+    when "text"
+      response_data["text"]
+    when "block_option_id"
+      BlockOption.find(response_data["block_option_id"]).key
+    end
+  end
+
+  def extract_name_from_survey_response(sr)
+    return sr.respondent&.name if sr.respondent.present?
+
+    sr.responses.find_by(block_id: Block.find_by(question: "Full Name:")&.id)&.response_data&.[]("text")
+  end
+
+  def extract_email_from_survey_response(sr)
+    return sr.respondent_email if sr.respondent_email.present?
+
+    sr.responses.find_by(block_id: Block.find_by(question: "Email:")&.id)&.response_data&.[]("text")
+  end
+
+  def filtered_responses(sr)
+    excluded_question_blocks = ["Email:", "Full Name:"]
+    sr.responses.reject { |response| excluded_question_blocks.include?(response.block.question) }
+  end
+end

--- a/app/views/assessments/_assessment_preview.html.erb
+++ b/app/views/assessments/_assessment_preview.html.erb
@@ -8,7 +8,10 @@
     <%= l assessment.created_at, format: :long %>
   </div>
   <% if action_name != "show" %>
-    <%= link_to "View this assessment", assessment, class: "btn btn-secondary" %>
+    <%= link_to I18n.t('assessments.preview.view'), assessment, class: "btn btn-secondary" %>
+  <% end %>
+  <% if Current.account_user&.admin? && assessment.submitted? %>
+    <%= link_to I18n.t('assessments.preview.download'), assessment, class: "btn btn-secondary" %>
   <% end %>
 </div>
 <hr>

--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -17,10 +17,10 @@
   <%= tag.div id: ("assessments" if first_page?), class: "bg-white dark:bg-gray-900 dark:border dark:border-gray-700 rounded-md shadow p-6 space-y-8" do %>
     <%= render partial: "assessments/assessment_preview", collection: @assessments, as: :assessment, cached: true %>
     <% if Current.account_user&.admin? %>
-    <div class="hidden only:block text-center">
-      <p class="mb-4 h3">Create your first Assessment</p>
-      <%= link_to t("scaffold.new.title", model: "Assessment"), new_assessment_path, class: "btn btn-primary" %>
-    </div>
+      <div class="hidden only:block text-center">
+        <p class="mb-4 h3">Create your first Assessment</p>
+        <%= link_to t("scaffold.new.title", model: "Assessment"), new_assessment_path, class: "btn btn-primary" %>
+      </div>
     <% end %>
   <% end %>
   <% if @pagy.pages > 1 %>

--- a/app/views/blocks/previews/_long_text.html.erb
+++ b/app/views/blocks/previews/_long_text.html.erb
@@ -3,7 +3,9 @@
   <% if block.description.present? %>
     <p class="mt-1 text-sm leading-6 text-gray-600"><%= block.description %></p>
   <% end %>
-  <%= form.text_area :response_data, class: 'form-control', placeholder: block.placeholder,
+  <%= form.text_area :response_data,
+                      name: "survey_response[responses_attributes][][response_data][text]", 
+                      class: 'form-control', placeholder: block.placeholder,
                       rows: 4,
                       required: block.required? %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -201,7 +201,9 @@ en:
       name: "Name"
       survey_template_version: "Survey Template Version"
       default_name: "Services Health Check"
-
+    preview:
+      view: "View this assessment"
+      download: "Download submissions"
   oauth:
     sign_in_with: "Sign in with %{provider}"
     apple: "Apple"

--- a/test/controllers/survey_responses_controller_test.rb
+++ b/test/controllers/survey_responses_controller_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class SurveyResponsesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @account = accounts(:one)
+    sign_in_as_admin(@user, @account)
+    @survey_response = survey_responses(:one)
+    @assessment = assessments(:one)
+  end
+
+  test "should create survey_response stamped with a user id and email address with a logged in user" do
+    assert_difference("SurveyResponse.count") do
+      post public_survey_responses_url, params: {token: @assessment.token, survey_response: {responses_attributes: [block_id: blocks(:one).id, response_data: [text: "Short answer"]]}}
+    end
+
+    assert_equal 2, SurveyResponse.where(respondent_id: @user.id).count
+    assert_equal 2, SurveyResponse.where(respondent_email: @user.email).count
+
+    assert_redirected_to thank_you_public_survey_response_url(token: @assessment.token), notice: "Thank you for completing the survey!"
+  end
+end

--- a/test/fixtures/block_options.yml
+++ b/test/fixtures/block_options.yml
@@ -1,13 +1,15 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
+  id: 1
   block: one
-  key: MyString
+  key: Option 1
   value: MyString
   position: 1
 
 two:
+  id: 2
   block: two
-  key: MyString
+  key: Option 2
   value: MyString
   position: 1

--- a/test/fixtures/blocks.yml
+++ b/test/fixtures/blocks.yml
@@ -3,13 +3,20 @@
 one:
   template_version: one
   block_type: 1
-  question: MyString
+  question: Some Question
   position: 1
-  config: 
+  config:
 
 two:
   template_version: two
   block_type: 1
-  question: MyString
+  question: Another Question
   position: 1
-  config: 
+  config:
+
+three:
+  template_version: two
+  block_type: 1
+  question: Alternative Question
+  position: 1
+  config:

--- a/test/fixtures/responses.yml
+++ b/test/fixtures/responses.yml
@@ -3,9 +3,14 @@
 one:
   block: one
   survey_response: one
-  response_data: 
+  response_data: { text: "My name is Sean Paul" }
 
 two:
   block: two
   survey_response: two
-  response_data: 
+  response_data: { block_option_id: 2 }
+
+three:
+  block: three
+  survey_response: one
+  response_data: { block_option_id: 1 }

--- a/test/fixtures/survey_responses.yml
+++ b/test/fixtures/survey_responses.yml
@@ -2,10 +2,12 @@
 
 one:
   assessment: one
-  respondent_email: MyString
+  respondent_email: one@example.com
   completed_at: 2024-11-25 14:05:36
+  respondent: one
 
 two:
   assessment: two
-  respondent_email: MyString
+  respondent_email: user-two@email.com
   completed_at: 2024-11-25 14:05:36
+  respondent: two

--- a/test/services/convert_responses_to_csv_test.rb
+++ b/test/services/convert_responses_to_csv_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+require "csv"
+
+class ConvertResponsesToCsvTest < ActiveSupport::TestCase
+  fixtures :assessments, :survey_responses, :responses, :blocks, :block_options
+
+  def setup
+    @assessment = assessments(:one)
+  end
+
+  test "should generate CSV string with respondent and respondent_email present" do
+    survey_response = @assessment.survey_responses.first
+
+    csv_string = ConvertResponsesToCsv.new(@assessment).export_responses_to_csv
+    csv = CSV.parse(csv_string, headers: true)
+
+    assert_equal ["Name", "Email", "Submitted On", "Some Question", "Alternative Question"], csv.headers
+    assert_equal survey_response.respondent.name, csv[0]["Name"]
+    assert_equal survey_response.respondent_email, csv[0]["Email"]
+    assert_equal "My name is Sean Paul", csv[0]["Some Question"]
+    assert_equal "Option 1", csv[0]["Alternative Question"]
+  end
+
+  test "should generate CSV string without respondent and respondent_email but with Email and Full Name blocks" do
+    survey_response = @assessment.survey_responses.first
+    survey_response.respondent = nil
+    survey_response.respondent_email = nil
+    survey_response.save!
+    block_1 = Block.create!(template_version: @assessment.template_version, question: "Email:", block_type: "short_text")
+    block_2 = Block.create!(template_version: @assessment.template_version, question: "Full Name:", block_type: "short_text")
+    Response.create!(survey_response: survey_response, block: block_1, response_data: {"text" => "anonymous-user@example.com"})
+    Response.create!(survey_response: survey_response, block: block_2, response_data: {"text" => "Anonymous User"})
+
+    csv_string = ConvertResponsesToCsv.new(@assessment).export_responses_to_csv
+    csv = CSV.parse(csv_string, headers: true)
+
+    assert_equal ["Name", "Email", "Submitted On", "Some Question", "Alternative Question"], csv.headers
+    assert_equal "Anonymous User", csv[0]["Name"]
+    assert_equal "anonymous-user@example.com", csv[0]["Email"]
+  end
+end


### PR DESCRIPTION
This PR:

- Adds 'Full Name' and 'Email' blocks to surveys automatically (for use by those completing the survey via a link); does not add and display these for users who have a log in, setting their email address and name from `Current.user`.
- Adds `ConvertResponsesToCsv` service class to gather survey responses and relevant block information and convert it to a readable format on a CSV. 
- Fixes some problems with survey responses where long text responses were not being correctly stored
- Tests service class and controller