### PR TITLE
HC-46 Parent Account Assigning Permissions Tweak and Parent Account Assessment Display

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -99,7 +99,7 @@ class AccountsController < Accounts::BaseController
   end
 
   def set_parent_accounts
-    @parent_accounts = Account.where(is_parent: true)
+    @parent_accounts = current_user.accounts.where(is_parent: true)
   end
 
   # Only allow a trusted parameter "allow list" through.

--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -5,27 +5,45 @@
     <div>
       <h1 class="h3"><%= t('assessments.index.assessments') %></h1>
       <div class="text-sm font-medium">
-        <span class="text-gray-500 dark:text-gray-300/75">Sort by:</span>
-        <%= sortable @assessments, :name, "Name", class: "text-gray-700 dark:text-gray-300 mr-1" %>
-        <%= sortable @assessments, :created_at, "Created", class: "text-gray-700 dark:text-gray-300 mr-1" %>
+        <% if !current_account.is_parent? %>
+          <span class="text-gray-500 dark:text-gray-300/75">Sort by:</span>
+          <%= sortable @assessments, :name, "Name", class: "text-gray-700 dark:text-gray-300 mr-1" %>
+          <%= sortable @assessments, :created_at, "Created", class: "text-gray-700 dark:text-gray-300 mr-1" %>
+        <% end %>
       </div>
     </div>
-    <% if Current.account_user&.admin? %>
+    <% if Current.account_user&.admin? && !current_account.is_parent? %>
       <%= link_to t("scaffold.new.title", model: "Assessment"), new_assessment_path, class: "btn btn-secondary" %>
     <% end %>
   </div>
-  <%= tag.div id: ("assessments" if first_page?), class: "bg-white dark:bg-gray-900 dark:border dark:border-gray-700 rounded-md shadow p-6 space-y-8" do %>
-    <%= render partial: "assessments/assessment_preview", collection: @assessments, as: :assessment, cached: true %>
-    <% if Current.account_user&.admin? %>
-      <div class="hidden only:block text-center">
-        <p class="mb-4 h3"><%= t('assessments.index.create_assessment') %></p>
-        <%= link_to t("scaffold.new.title", model: "Assessment"), new_assessment_path, class: "btn btn-primary" %>
-      </div>
+
+  <% if current_account.is_parent? %>
+    <% current_account.child_accounts.each do |child_account| %>
+      <% child_assessments = child_account.assessments %>
+      <% if child_assessments.any? %>
+        <div class="mb-8">
+          <h2 class="text-xl font-semibold mb-4"><%= child_account.name %></h2>
+          <div class="bg-white dark:bg-gray-900 dark:border dark:border-gray-700 rounded-md shadow p-6 space-y-8">
+            <%= render partial: "assessments/assessment_preview", collection: child_assessments, as: :assessment, cached: true %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  <% else %>
+    <%= tag.div id: ("assessments" if first_page?), class: "bg-white dark:bg-gray-900 dark:border dark:border-gray-700 rounded-md shadow p-6 space-y-8" do %>
+      <%= render partial: "assessments/assessment_preview", collection: @assessments, as: :assessment, cached: true %>
+      <% if Current.account_user&.admin? && !current_account.is_parent? %>
+        <div class="hidden only:block text-center">
+          <p class="mb-4 h3"><%= t('assessments.index.create_assessment') %></p>
+          <%= link_to t("scaffold.new.title", model: "Assessment"), new_assessment_path, class: "btn btn-primary" %>
+        </div>
+      <% end %>
     <% end %>
   <% end %>
+
   <% if @pagy.pages > 1 %>
     <div class="my-6 text-center">
-      <%== pagy_nav(@pagy) %>
+      <%= pagy_nav(@pagy) %>
     </div>
   <% end %>
 </div>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -1,12 +1,16 @@
 <div class="container mx-auto p-4">
   <div class="my-8">
     <div class="flex items-center justify-between mb-4">
-      <h1><%= current_account.name %> - <%= t(".title") %></h1>
-      <% if Current.account_user&.admin? && current_account.assessments&.blank? %>
+      <% if current_account.is_parent? %>
+        <h1><%= t('dashboard.show.all_assessments') %></h1>
+      <% else %>
+        <h1><%= current_account.name %> - <%= t(".title") %></h1>
+      <% end %>
+      <% if Current.account_user&.admin? && current_account.assessments&.blank? && !current_account.is_parent? %>
       <%= link_to t("scaffold.new.title", model: "Assessment"), new_assessment_path, class: "btn btn-secondary" %>
       <% end %>
     </div>
-    <% if Current.account_user&.admin? && current_account.assessments&.blank? %>
+    <% if Current.account_user&.admin? && current_account.assessments&.blank? && !current_account.is_parent? %>
     <div class="bg-white dark:bg-gray-900 dark:border dark:border-gray-700 rounded-md shadow p-6 space-y-8">
       <div class="block text-center">
         <p class="mb-4 h3"><%= t('assessments.index.create_assessment') %></p>
@@ -14,19 +18,45 @@
       </div>
     </div>
     <% end %>
-    <table class="w-full my-4">
-      <tbody>
-        <% current_account.assessments.each do | assessment | %>
-          <tr class="border-t border-gray-100 dark:border-gray-800 group">
-            <td class="p-3">
-              <%= link_to assessment, class:"flex items-center" do %>
-                <span class="text-gray-900 dark:text-gray-100 font-semibold text-sm no-underline hover:text-primary-500 dark:hover:text-primary-500"><%= assessment.name %></span>
-                <%= assessment_label(assessment, classes: "ml-2") %>
-              <% end %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
+    <% if current_account.is_parent? %>
+      <% current_account.child_accounts.each do |child_account| %>
+        <div class="mb-6">
+          <h2 class="text-xl font-bold mb-3"><%= child_account.name %></h2>
+          <% if child_account.assessments.any? %>
+            <table class="w-full my-2">
+              <tbody>
+                <% child_account.assessments.each do |assessment| %>
+                  <tr class="border-t border-gray-100 dark:border-gray-800 group">
+                    <td class="p-3">
+                      <%= link_to assessment, class:"flex items-center" do %>
+                        <span class="text-gray-900 dark:text-gray-100 font-semibold text-sm no-underline hover:text-primary-500 dark:hover:text-primary-500"><%= assessment.name %></span>
+                        <%= assessment_label(assessment, classes: "ml-2") %>
+                      <% end %>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          <% else %>
+            <p class="text-gray-500 italic">No assessments</p>
+          <% end %>
+        </div>
+      <% end %>
+    <% else %>
+      <% current_account.assessments.each do | assessment | %>
+        <table class="w-full">
+          <tbody>
+            <tr class="border-t border-gray-100 dark:border-gray-800 group">
+              <td class="p-3">
+                <%= link_to assessment, class:"flex items-center" do %>
+                  <span class="text-gray-900 dark:text-gray-100 font-semibold text-sm no-underline hover:text-primary-500 dark:hover:text-primary-500"><%= assessment.name %></span>
+                  <%= assessment_label(assessment, classes: "ml-2") %>
+                <% end %>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -201,6 +201,7 @@ en:
   dashboard:
     show:
       title: "Assessments"
+      all_assessments: "All Assessments"
 
   assessments:
     index:


### PR DESCRIPTION
- Only show parent account options in the assignment dropdown for parent accounts that the user belongs to.
- Adjust dashboards#show and assessments#index for parent accounts so that we see all assessments for all child accounts rather than creating assessments link.