### PR TITLE
HC-49 Fix assessments link redirect in parent account view

### DIFF
--- a/app/views/assessments/_assessment_preview.html.erb
+++ b/app/views/assessments/_assessment_preview.html.erb
@@ -7,7 +7,7 @@
     <p class="text-sm font-medium text-gray-500">Created</p>
     <%= l assessment.created_at, format: :long %>
   </div>
-  <% if action_name != "show" %>
+  <% if action_name != "show" && !current_account.is_parent? %>
     <%= link_to I18n.t('assessments.preview.view'), assessment, class: "btn btn-secondary" %>
   <% end %>
   <% if Current.account_user&.admin? && assessment.submitted? && assessment.export_bundle&.completed? %>

--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -23,6 +23,7 @@
       <% if child_assessments.any? %>
         <div class="mb-8">
           <h2 class="text-xl font-semibold mb-4"><%= child_account.name %></h2>
+          <%= button_to I18n.t('assessments.preview.view_account'), switch_account_path(child_account), method: :patch, class: "btn btn-secondary" %>
           <div class="bg-white dark:bg-gray-900 dark:border dark:border-gray-700 rounded-md shadow p-6 space-y-8">
             <%= render partial: "assessments/assessment_preview", collection: child_assessments, as: :assessment, cached: true %>
           </div>

--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -22,8 +22,10 @@
       <% child_assessments = child_account.assessments %>
       <% if child_assessments.any? %>
         <div class="mb-8">
+          <div class="flex items-center justify-between mb-4">
           <h2 class="text-xl font-semibold mb-4"><%= child_account.name %></h2>
           <%= button_to I18n.t('assessments.preview.view_account'), switch_account_path(child_account), method: :patch, class: "btn btn-secondary" %>
+          </div>
           <div class="bg-white dark:bg-gray-900 dark:border dark:border-gray-700 rounded-md shadow p-6 space-y-8">
             <%= render partial: "assessments/assessment_preview", collection: child_assessments, as: :assessment, cached: true %>
           </div>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -28,9 +28,14 @@
                 <% child_account.assessments.each do |assessment| %>
                   <tr class="border-t border-gray-100 dark:border-gray-800 group">
                     <td class="p-3">
-                      <%= link_to assessment, class:"flex items-center" do %>
-                        <span class="text-gray-900 dark:text-gray-100 font-semibold text-sm no-underline hover:text-primary-500 dark:hover:text-primary-500"><%= assessment.name %></span>
-                        <%= assessment_label(assessment, classes: "ml-2") %>
+                      <% if current_account.is_parent? %>
+                        <span class="text-gray-900 dark:text-gray-100 font-semibold text-sm no-underline"><%= assessment.name %></span>
+                        <%= assessment_label(assessment, classes: 'ml-2') %>
+                      <% else %>
+                        <%= link_to assessment, class:"flex items-center" do %>
+                          <span class="text-gray-900 dark:text-gray-100 font-semibold text-sm no-underline hover:text-primary-500 dark:hover:text-primary-500"><%= assessment.name %></span>
+                          <%= assessment_label(assessment, classes: "ml-2") %>
+                        <% end %>
                       <% end %>
                     </td>
                   </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,6 +223,7 @@ en:
       assessment_completed: "Assessment completed"
     preview:
       view: "View this assessment"
+      view_account: "View this account"
       download: "Download submissions"
     download_analysis:
       no_file: "No file available for download."


### PR DESCRIPTION
**Problem:**
In the parent account, the assessment title links on the assessments dashboard and index do not redirect anywhere. 

**Solution:**
For the sake of limited time for now, remove the links on the dashboard and just display plain text titles.
Add a button to the assessments index next to each account name; 'view this account'. This will allow the user to navigate into the account where they can perform normal assessment actions (e.g. view/submit/create assessments that are correctly scoped to the child account.