### PR TITLE
HC-56 Allow survey questionnaire to be optional

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -34,7 +34,9 @@ class AssessmentsController < ApplicationController
     if @assessment.include_finance_check == "1"
       @assessment.build_finance_check
     end
-    @assessment.build_survey_check
+    if @assessment.template_version_id.present?
+      @assessment.build_survey_check
+    end
     # Uncomment to authorize with Pundit
     # authorize @assessment
 

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -13,6 +13,7 @@ class Assessment < ApplicationRecord
   has_one_attached :file
 
   validates :name, presence: true
+  validate :at_least_one_check_present
 
   enum :status, %w[in_progress submitted completed].index_by(&:itself)
   translate_enum :status
@@ -26,5 +27,11 @@ class Assessment < ApplicationRecord
       (survey_check.nil? || survey_check.complete?) &&
       (sow_check.nil? || sow_check.complete?) &&
       (finance_check.nil? || finance_check.complete?)
+  end
+
+  def at_least_one_check_present
+    if survey_check.nil? && sow_check.nil? && finance_check.nil?
+      errors.add(:base, message: I18n.t("activerecord.errors.models.assessment.no_checks"))
+    end
   end
 end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -4,7 +4,7 @@ class Assessment < ApplicationRecord
   broadcasts_refreshes
   acts_as_tenant :account
   belongs_to :account
-  belongs_to :template_version
+  belongs_to :template_version, optional: true
   has_one :sow_check, dependent: :destroy
   has_one :finance_check, dependent: :destroy
   has_one :survey_check, dependent: :destroy
@@ -22,6 +22,9 @@ class Assessment < ApplicationRecord
   attr_accessor :include_sow_check, :include_finance_check
 
   def submittable?
-    in_progress? && survey_check&.complete? && sow_check&.complete? && finance_check&.complete?
+    in_progress? &&
+      (survey_check.nil? || survey_check.complete?) &&
+      (sow_check.nil? || sow_check.complete?) &&
+      (finance_check.nil? || finance_check.complete?)
   end
 end

--- a/app/views/assessments/_assessment.html.erb
+++ b/app/views/assessments/_assessment.html.erb
@@ -94,7 +94,7 @@
               </div>
             </div>
           </div>
-          <%= render assessment.template_version, assessment: assessment %>
+          <%= render assessment.template_version, assessment: assessment if assessment.template_version_id %>
           <%= render assessment.sow_check if assessment.sow_check %>
           <%= render assessment.finance_check if assessment.finance_check %>
         </div>

--- a/app/views/assessments/_form.html.erb
+++ b/app/views/assessments/_form.html.erb
@@ -20,7 +20,7 @@
     </div>
     <div class="form-group">
       <%= form.label :template_version_id do %> 
-        <%= I18n.t('assessments.new.survey_template_version') %> <span style="color: red;">*</span>
+        <%= I18n.t('assessments.new.survey_template_version') %></span>
       <% end %>
         <div class="input-group">
           <%= form.collection_select :template_version_id, 
@@ -29,6 +29,7 @@
           .order('survey_templates.name ASC, template_versions.version_number DESC'),
           :id, 
           ->template_version { "#{template_version.survey_template.name} - #{template_version.notes}" },
+          { include_blank: t('assessments.new.no_survey')},
           { class: "form-control", data: { action: "auto-submit#submit" } } %>
         </div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -642,6 +642,8 @@ en:
           attributes:
             admin:
               cannot_be_removed: "role cannot be removed for the account owner"
+        assessment:
+          no_checks: "At least one check type (Survey, Finance, or SOW) must be included"
 
   errors:
     messages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -211,6 +211,7 @@ en:
     new:
       name: "Name"
       survey_template_version: "Survey Template Version"
+      no_survey: "No survey"
       default_name: "Services Health Check"
     show:
       assessment_input: "Assessment Input"

--- a/test/controllers/assessments_controller_test.rb
+++ b/test/controllers/assessments_controller_test.rb
@@ -26,7 +26,32 @@ class AssessmentsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to assessment_url(Assessment.last)
   end
 
-  # add tests for creating sow_check, finance_check, survey_check
+  test "should create assessment with sow_check" do
+    assert_difference("Assessment.count") do
+      post assessments_url, params: {assessment: {account_id: @assessment.account_id, name: @assessment.name, template_version_id: @assessment.template_version.id, include_sow_check: "1"}}
+    end
+    assert_redirected_to assessment_url(Assessment.last)
+    assessment = Assessment.last
+    assert_not_nil assessment.sow_check
+  end
+
+  test "should create assessment with finance_check" do
+    assert_difference("Assessment.count") do
+      post assessments_url, params: {assessment: {account_id: @assessment.account_id, name: @assessment.name, template_version_id: @assessment.template_version.id, include_finance_check: "1"}}
+    end
+    assert_redirected_to assessment_url(Assessment.last)
+    assessment = Assessment.last
+    assert_not_nil assessment.finance_check
+  end
+
+  test "should create assessment with survey_check" do
+    assert_difference("Assessment.count") do
+      post assessments_url, params: {assessment: {account_id: @assessment.account_id, name: @assessment.name, template_version_id: @assessment.template_version.id}}
+    end
+    assert_redirected_to assessment_url(Assessment.last)
+    assessment = Assessment.last
+    assert_not_nil assessment.survey_check
+  end
 
   test "should show assessment" do
     get assessment_url(@assessment)

--- a/test/controllers/assessments_controller_test.rb
+++ b/test/controllers/assessments_controller_test.rb
@@ -26,6 +26,8 @@ class AssessmentsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to assessment_url(Assessment.last)
   end
 
+  # add tests for creating sow_check, finance_check, survey_check
+
   test "should show assessment" do
     get assessment_url(@assessment)
     assert_response :success

--- a/test/workers/export_bundle_worker_test.rb
+++ b/test/workers/export_bundle_worker_test.rb
@@ -45,9 +45,9 @@ class ExportBundleWorkerTest < ActiveSupport::TestCase
     assert_equal "completed", @export_bundle.status
   end
 
-  test "should set export_bundle status to errored if file is not attached" do
-    @worker.stubs(:generate_csv).returns("mock_csv_content")
-    @worker.stubs(:create_zip_file).raises(StandardError.new("File creation failed"))
+  test "should set export_bundle status to errored if there are no files to include" do
+    @assessment.survey_responses.destroy_all
+    @worker.stubs(:collect_attachments_into_dir).returns([])
 
     @worker.perform(@assessment.id)
 


### PR DESCRIPTION
- Change views and controller logic to allow optional surveys
- Change export bundle worker to only build a zip file if other attachments are present to be downloaded - otherwise just attach the CSV for download.
- Add a validation on the assessment to check for at least one of the three checks to be present before save.