### PR TITLE
HC-54 Fix name and email in survey responses CSV

### DIFF
--- a/app/services/convert_responses_to_csv.rb
+++ b/app/services/convert_responses_to_csv.rb
@@ -52,13 +52,13 @@ class ConvertResponsesToCsv
   def extract_name_from_survey_response(sr)
     return sr.respondent&.name if sr.respondent.present?
 
-    sr.responses.find_by(block_id: Block.find_by(question: "Full Name:")&.id)&.response_data&.[]("text")
+    sr.responses.find_by(block_id: @assessment.template_version.blocks.find_by(question: "Full Name:")&.id)&.response_data&.[]("text")
   end
 
   def extract_email_from_survey_response(sr)
     return sr.respondent_email if sr.respondent_email.present?
 
-    sr.responses.find_by(block_id: Block.find_by(question: "Email:")&.id)&.response_data&.[]("text")
+    sr.responses.find_by(block_id: @assessment.template_version.blocks.find_by(question: "Email:")&.id)&.response_data&.[]("text")
   end
 
   def filtered_responses(sr)

--- a/test/services/convert_responses_to_csv_test.rb
+++ b/test/services/convert_responses_to_csv_test.rb
@@ -6,6 +6,13 @@ class ConvertResponsesToCsvTest < ActiveSupport::TestCase
 
   def setup
     @assessment = assessments(:one)
+    template_version_two = template_versions(:two)
+    survey_response_two = survey_responses(:two)
+    # ensure that the csv generator retrieves the correct name and email blocks
+    block_1 = Block.create!(question: "Full Name:", block_type: "short_text", template_version: template_version_two)
+    block_2 = Block.create!(question: "Email:", block_type: "short_text", template_version: template_version_two)
+    Response.create!(survey_response: survey_response_two, block: block_1, response_data: {"text" => "wrong-name@example.com"})
+    Response.create!(survey_response: survey_response_two, block: block_2, response_data: {"text" => "WRONG NAME"})
   end
 
   test "should generate CSV string with respondent and respondent_email present" do


### PR DESCRIPTION
Problem:
A bug was leading to name and email not pulling through on the CSV for users without accounts.

Solution:
Adjustment to Block query, and scenario represented in spec.